### PR TITLE
Remove hardcoded github token from discovery-python dep link.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,5 @@
+env:
+  - GITHUB_API_TOKEN=$$github_token
 image: clever/drone-go:1.5
 notify:
   email:

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ A service for recording client-side events and errors via the Clever logging pip
 
 ##### pip
 
-```sh
-pip install git+https://<clever-drone Github token>@github.com/Clever/kayvee-logger-service.git@<version_tag>#egg=kayvee-logger-service
-```
+Assuming kayvee-logger-service v1.0.0 is being installed:
 
-The Github token can be found in [dev-passwords](https://github.com/Clever/clever-ops/tree/master/credentials).
+```sh
+pip install git+ssh://@github.com/Clever/kayvee-logger-service.git@v1.0.0#egg=kayvee-logger-service
+```
 
 ##### setup.py
 
 ```python
 from setuptools import setup
+
+GITHUB_TOKEN = os.environ['GITHUB_API_TOKEN']
 
 # Assuming kayvee-logger-service v1.0.0 is being installed:
 setup(
@@ -29,15 +31,13 @@ setup(
 
     install_requires=['kayvee-logger-service==1.0.0'],
     dependency_links=[
-      'https://<clever-drone Github token>@github.com/Clever/kayvee-logger-service/tarball/v1.0.0#egg=kayvee-logger-service-1.0.0'
+      'https://{}@github.com/Clever/kayvee-logger-service/tarball/v1.0.0#egg=kayvee-logger-service-1.0.0'.format(GITHUB_TOKEN)
     ],
 
     # ...
 
 )
 ```
-
-The Github token can be found in [dev-passwords](https://github.com/Clever/clever-ops/tree/master/credentials).
 
 #### Usage:
 

--- a/client/python/dependency-links.txt
+++ b/client/python/dependency-links.txt
@@ -1,1 +1,0 @@
-https://ee5497304fd194fc4d3616283d55abe1e80e6db6@github.com/Clever/discovery-python/tarball/v0.1.0#egg=discovery-0.1.0

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ from setuptools import setup, find_packages
 NAME = "kayvee_logger_service"
 VERSION = "1.0.0"
 
+GITHUB_TOKEN = os.environ['GITHUB_API_TOKEN']
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 reqs = 'client/python/requirements.txt'
@@ -22,9 +24,6 @@ if pkg_resources.get_distribution("pip").version >= '6.0':
 
 install_reqs = parse_requirements(os.path.join(here, reqs), **pr_kwargs)
 
-with open(os.path.join(here, 'client/python/dependency-links.txt')) as f:
-  dep_links = f.read().splitlines()
-
 setup(
     name=NAME,
     version=VERSION,
@@ -33,7 +32,10 @@ setup(
     url="https://github.com/Clever/kayvee-logger-service",
     keywords=["Swagger", "Kayvee Logger Service"],
     install_requires=[str(ir.req) for ir in install_reqs if ir.req is not None],
-    dependency_links=[dep.strip() for dep in dep_links if dep],
+    dependency_links=[
+        'https://{}@github.com/Clever/discovery-python/tarball/v0.1.0#egg=discovery-0.1.0'.format(
+            GITHUB_TOKEN)
+    ],
     packages=find_packages('client/python', exclude=['test']),
     package_dir={'': 'client/python'},
     long_description="""\


### PR DESCRIPTION
- Retrieve the token from the `GITHUB_API_TOKEN` env var instead.
- The env var is available on VMs and is set in drone via private variables.
- Also update README instructions on installing the python client.
